### PR TITLE
Add support for American datetimes [#96008470]

### DIFF
--- a/lib/american_date_parsing.rb
+++ b/lib/american_date_parsing.rb
@@ -8,7 +8,7 @@ module AmericanDateParsing
   end
 
   def self.default_format
-    @default_format ||= %r{\d{1,2}#{delimiter}\d{1,2}#{delimiter}\d{2,4}}
+    @default_format ||= %r{\d{1,2}#{delimiter}\d{1,2}#{delimiter}\d{2,4}( \d{1,2}:\d{2}( )?(PM|AM))?}
   end
 
   mattr_accessor :date_format do
@@ -31,9 +31,9 @@ module AmericanDateParsing
 
       define_method "#{attribute}=" do |date_string|
         parsed = if date_string.respond_to?(:strftime)
-          date_string.to_date
+          date_string.to_datetime
         else
-          Chronic.parse(date_string.to_s).try(:to_date)
+          Chronic.parse(date_string.to_s).try(:to_datetime)
         end
 
         send(:"_raw_#{attribute}=", date_string)

--- a/lib/american_date_parsing/version.rb
+++ b/lib/american_date_parsing/version.rb
@@ -1,3 +1,3 @@
 module AmericanDateParsing
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
Needed to add this for American datetimes in another story. I believe this would continue supporting dates as well, as the regex supports both dates and datetimes.

![](https://31.media.tumblr.com/9595502384cb2dfd2eff6f1506c40212/tumblr_nx5n22fOjD1uz2g97o1_500.gif)
